### PR TITLE
Oleksandr dreval

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,29 @@ This script provides an interactive way to rewrite Git commit messages using `gi
 
 The main goal of this script is to offer a user-friendly interface for an otherwise complex Git operation: interactively rebasing commits to change their messages. It guides the user through the process, from selecting which commits to reword to handling potential pauses during the rebase.
 
+## Options
+
+*   `-h`, `--help`: Show the help message and exit.
+*   `-d`, `--default`: Use default Git editor selection (checks `GIT_EDITOR`, then `EDITOR`, then falls back to `nano`).
+*   `-e <EDITOR>`, `--editor=<EDITOR>`: Specify the Git editor to use (e.g., `nano`, `vim`, `code --wait`).
+
 ## Functionality
 
 The script performs the following key functions:
 
-1.  **Select Rebase Scope**: Allows the user to choose whether to reword commits from:
+1.  **Handle Uncommitted Changes**: Detects if there are uncommitted changes and prompts the user to either stash them temporarily or exit the script.
+2.  **Select Rebase Scope**: Allows the user to choose whether to reword commits from:
     *   The very first commit (root).
     *   The last N commits.
     *   A specific commit by its hash.
-2.  **Interactive Rebasing**: Initiates `git rebase -i` with the chosen scope.
-3.  **Guidance for Editor**: Provides clear instructions on how to use the interactive rebase editor (defaulting to Nano if `GIT_EDITOR` or `EDITOR` are not set):
+3.  **Interactive Rebasing**: Initiates `git rebase -i` with the chosen scope.
+4.  **Guidance for Editor**: Provides clear instructions on how to use the interactive rebase editor (defaulting to Nano if `GIT_EDITOR` or `EDITOR` are not set, or using the specified editor):
     *   How to change `pick` to `reword` (or `r`).
-    *   How to use `edit` (or `e`) to pause the rebase at a specific commit for inspection or conflict resolution.
+    *   How to use `edit` (or `e`) to pause the rebase at a specific commit for inspection, conflict resolution, or making additional changes.
     *   Instructions for saving and closing editor files.
-4.  **Conventional Commits Reminder**: Reminds users to follow Conventional Commits guidelines when rewriting messages.
-5.  **Rebase Pause Handling**: Detects if `git rebase` has paused (e.g., due to an `edit` command or conflicts) and offers options to `continue`, `abort`, or `exit` the script while leaving the rebase in a paused state.
-6.  **Post-Rebase Instructions**: After successful rebase, it reminds the user to force push changes to the remote repository if necessary and to check their Git history.
+5.  **Conventional Commits Reminder**: Reminds users to follow Conventional Commits guidelines when rewriting messages.
+6.  **Rebase Pause Handling**: Detects if `git rebase` has paused (e.g., due to an `edit` command or conflicts) and offers options to `continue`, `abort`, or `exit` the script while leaving the rebase in a paused state.
+7.  **Post-Rebase Instructions**: After successful rebase, it reminds the user to force push changes to the remote repository if necessary and to check their Git history.
 
 ## How to Use
 
@@ -30,23 +37,28 @@ The script performs the following key functions:
     ```bash
     chmod +x reword_commits.sh
     ```
-3.  **Run the Script**: Execute the script from your terminal within your Git repository:
+3.  **Run the Script**: Execute the script from your terminal within your Git repository. You can specify an editor or use the default:
     ```bash
     ./reword_commits.sh
+    ./reword_commits.sh --editor=vim
+    ./reword_commits.sh -e code --wait
+    ./reword_commits.sh --default
     ```
-4.  **Choose Rebase Option**: Follow the prompts to select how you want to rewrite your history:
-    *   `1`: From the first commit.
+4.  **Handle Uncommitted Changes (if prompted)**: If you have uncommitted changes, the script will ask you to `(s) stash` them or `(e) exit`. Choose `s` to temporarily save your changes and proceed, or `e` to exit and handle them manually.
+5.  **Choose Rebase Option**: Follow the prompts to select how you want to rewrite your history:
+    *   `1`: From the first commit (root).
     *   `2`: For the last N commits (you'll be asked for the number).
-    *   `3`: For a specific commit (you'll be asked for the commit hash).
-5.  **Interactive Editor Instructions**: Read the on-screen instructions carefully before pressing Enter to proceed. These instructions explain how to modify the rebase plan in your default text editor (e.g., Nano, Vim, VS Code).
+    *   `3`: For a specific commit by its full hash (you'll be asked for the commit hash).
+6.  **Interactive Editor Instructions**: Read the on-screen instructions carefully before pressing Enter to proceed. These instructions explain how to modify the rebase plan in your default text editor (e.g., Nano, Vim, VS Code).
     *   Change `pick` to `reword` (or `r`) for any commit you wish to modify its message.
-    *   Change `pick` to `edit` (or `e`) if you want to pause the rebase at a specific commit to make other changes or resolve conflicts.
-6.  **Rewrite Commit Messages**: For each commit marked `reword`, your editor will open. Change the commit message as desired, adhering to Conventional Commits standards (e.g., `feat(scope): descriptive message`). Save and close the editor for each message.
-7.  **Handle Pauses (if any)**: If the rebase pauses (e.g., due to an `edit` command or conflicts), the script will prompt you to:
+    *   Change `pick` to `edit` (or `e`) if you want to pause the rebase at a specific commit to make other changes or resolve conflicts. If you choose this, the script will pause and provide options to continue or abort.
+7.  **Rewrite Commit Messages**: For each commit marked `reword`, your editor will open. Change the commit message as desired, adhering to Conventional Commits standards (e.g., `feat(scope): descriptive message`). Save and close the editor for each message.
+8.  **Handle Pauses (if any)**: If the rebase pauses (e.g., due to an `edit` command or conflicts), the script will prompt you to:
     *   `c`: Continue the rebase (after resolving any conflicts manually).
     *   `a`: Abort the rebase.
     *   `q`: Exit the script, leaving the rebase in a paused state.
-8.  **Force Push (if needed)**: After the rebase completes, if you have pushed these commits previously, you will likely need to force push your changes to the remote repository:
+9.  **Restore Stashed Changes (if applicable)**: If you stashed changes at the beginning, the script will remind you to restore them using `git stash pop` after the rebase is complete.
+10. **Force Push (if needed)**: After the rebase completes, if you have pushed these commits previously, you will likely need to force push your changes to the remote repository:
     ```bash
     git push --force-with-lease
     ```

--- a/reword_commits.sh
+++ b/reword_commits.sh
@@ -1,14 +1,33 @@
 #!/bin/bash
 
-echo "Script for interactive rewriting of commit messages."
-echo "This script will use 'git rebase -i' to modify Git history."
-echo "Be careful, changing history can have consequences."
-echo ""
+display_help() {
+    echo "Usage: $(basename "$0") [OPTIONS]"
+    echo "Script for interactively rewriting Git commit messages."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help               Show this help message and exit."
+    echo "  -e <EDITOR>, --editor=<EDITOR>"
+    echo "                           Specify the Git editor to use (e.g., nano, vim, code --wait)."
+    echo ""
+    echo "Examples:"
+    echo "  $(basename "$0")"
+    echo "  $(basename "$0") --help"
+    echo "  $(basename "$0") --editor=vim"
+    echo "  $(basename "$0") -e code --wait"
+    exit 0
+}
 
 CUSTOM_EDITOR=""
 
+if [ "$#" -eq 0 ]; then
+    display_help
+fi
+
 while (( "$#" )); do
     case "$1" in
+        -h|--help)
+            display_help
+            ;;
         --editor=*)
             CUSTOM_EDITOR="${1#*=}"
             shift
@@ -18,7 +37,7 @@ while (( "$#" )); do
                 CUSTOM_EDITOR="$2"
                 shift 2
             else
-                echo "Error: Argument for $1 is missing" >&2
+                echo "Error: Missing argument for $1" >&2
                 exit 1
             fi
             ;;
@@ -28,6 +47,11 @@ while (( "$#" )); do
             ;;
     esac
 done
+
+echo "Script for interactive rewriting of commit messages."
+echo "This script will use 'git rebase -i' to modify Git history."
+echo "Be careful, changing history can have consequences."
+echo ""
 
 changes_stashed=false
 

--- a/reword_commits.sh
+++ b/reword_commits.sh
@@ -6,6 +6,7 @@ display_help() {
     echo ""
     echo "Options:"
     echo "  -h, --help               Show this help message and exit."
+    echo "  -d, --default            Use default Git editor selection (GIT_EDITOR, EDITOR, then nano)."
     echo "  -e <EDITOR>, --editor=<EDITOR>"
     echo "                           Specify the Git editor to use (e.g., nano, vim, code --wait)."
     echo ""
@@ -14,10 +15,12 @@ display_help() {
     echo "  $(basename "$0") --help"
     echo "  $(basename "$0") --editor=vim"
     echo "  $(basename "$0") -e code --wait"
+    echo "  $(basename "$0") --default"
     exit 0
 }
 
 CUSTOM_EDITOR=""
+USE_DEFAULT_EDITOR=false
 
 if [ "$#" -eq 0 ]; then
     display_help
@@ -27,6 +30,10 @@ while (( "$#" )); do
     case "$1" in
         -h|--help)
             display_help
+            ;;
+        -d|--default)
+            USE_DEFAULT_EDITOR=true
+            shift
             ;;
         --editor=*)
             CUSTOM_EDITOR="${1#*=}"
@@ -156,7 +163,15 @@ echo "5. Save (Ctrl+O) and close (Ctrl+X) each message file to proceed to the ne
 echo ""
 read -p "Press Enter to continue and start interactive commit rewriting..."
 
-if [ -n "$CUSTOM_EDITOR" ]; then
+if [ "$USE_DEFAULT_EDITOR" = true ]; then
+    if [ -n "$GIT_EDITOR" ]; then
+        REBASE_EDITOR="$GIT_EDITOR"
+    elif [ -n "$EDITOR" ]; then
+        REBASE_EDITOR="$EDITOR"
+    else
+        REBASE_EDITOR="nano"
+    fi
+elif [ -n "$CUSTOM_EDITOR" ]; then
     REBASE_EDITOR="$CUSTOM_EDITOR"
 elif [ -n "$GIT_EDITOR" ]; then
     REBASE_EDITOR="$GIT_EDITOR"

--- a/reword_commits.sh
+++ b/reword_commits.sh
@@ -163,22 +163,18 @@ echo "5. Save (Ctrl+O) and close (Ctrl+X) each message file to proceed to the ne
 echo ""
 read -p "Press Enter to continue and start interactive commit rewriting..."
 
-if [ "$USE_DEFAULT_EDITOR" = true ]; then
-    if [ -n "$GIT_EDITOR" ]; then
-        REBASE_EDITOR="$GIT_EDITOR"
-    elif [ -n "$EDITOR" ]; then
-        REBASE_EDITOR="$EDITOR"
-    else
-        REBASE_EDITOR="nano"
-    fi
-elif [ -n "$CUSTOM_EDITOR" ]; then
-    REBASE_EDITOR="$CUSTOM_EDITOR"
-elif [ -n "$GIT_EDITOR" ]; then
+REBASE_EDITOR=""
+
+if [ -n "$GIT_EDITOR" ]; then
     REBASE_EDITOR="$GIT_EDITOR"
 elif [ -n "$EDITOR" ]; then
     REBASE_EDITOR="$EDITOR"
 else
     REBASE_EDITOR="nano"
+fi
+
+if [ "$USE_DEFAULT_EDITOR" = false ] && [ -n "$CUSTOM_EDITOR" ]; then
+    REBASE_EDITOR="$CUSTOM_EDITOR"
 fi
 
 GIT_SEQUENCE_EDITOR="$REBASE_EDITOR" git rebase -i "$rebase_command"


### PR DESCRIPTION
feat(script): Added editor selection and improved help functionality

This PR adds new features and improvements to the commit rewriting script `reword_commits.sh`.

The main changes include:

- **feat(editor)**: Added an option to select the default Git editor (`--default`) or specify your own editor (`-e` or `--editor`).
- **feat(help)**: Improved help functionality with more detailed usage instructions and examples, making the script more user-friendly.
- **refactor(editor)**: Simplified and optimized the editor selection logic, improving code readability and maintainability.
- **docs(readme)**: Updated the `README.md` file to reflect the new options and provided improved instructions for using the script.

