### PR TITLE
chore/add-gitignore-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@
 $RECYCLE.BIN/
 ehthumbs.db
 ehthumbs_vista.db
+env/
 Thumbs.db
 Thumbs.db:encryptable


### PR DESCRIPTION
Add 'env/' to .gitignore to exclude environment files from version control